### PR TITLE
Ensure JRE 1.8 loaded as module; add ShARC instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # scala-spark-HelloWorld
 How to compile and run a 'Hello World' application on Sheffield's HPC clusters.
 
-## Iceberg
-
-Get the example
+On Iceberg *only* activate a recent version of the git version control software:
 
 ```
 module load apps/gcc/5.2/git/2.5
+```
+
+Get the example
+```
 git clone https://github.com/mikecroucher/scala-spark-HelloWorld
 ```
 
@@ -16,11 +18,20 @@ Enter the project directory
 cd scala-spark-HelloWorld/
 ```
 
-Load the module files for sbt and spark
+Load the module files for sbt and spark.  On Iceberg do:
 
 ```
-module load /apps/binapps/sbt/0.13.13 
-module load /apps/gcc/4.4.7/spark/2.0
+module load apps/java/1.8u71
+module load apps/binapps/sbt/0.13.13 
+module load apps/gcc/4.4.7/spark/2.0
+```
+
+In ShARC do:
+
+```
+module load apps/java/jdk1.8.0_102/binary
+module load dev/sbt/0.13.13
+module load apps/spark/2.1.0/gcc-4.8.5
 ```
 
 Compile with 


### PR DESCRIPTION
Force a particular JRE to be loaded: ensures that our logic is used for limiting the JVM's use of virtual memory.

Also, add brief notes on how to run on ShARC.